### PR TITLE
Refactored

### DIFF
--- a/ldap.rkt
+++ b/ldap.rkt
@@ -1,9 +1,7 @@
 #lang racket/base
 
 (require racket/class
-         racket/contract
-         racket/bool
-         data/gvector
+         racket/contract         
          "ffi.rkt")
 
 (provide
@@ -16,8 +14,8 @@
                 [password (or/c string? #f)])
     [set-option (->m positive? positive? #t)]
     [bind   (->*m () ((or/c 0 1 2)) #t)]
-    [modify (->m string? (listof list?) #t)]
-    [add    (->m string? (listof list?) #t)]
+    [modify (->m string? mod-list? #t)]
+    [add    (->m string? mod-list? #t)]
     [delete (->m string? #t)]
     [search (->m string? string? (or/c 0 1 2) #t)]
     [get-data (->m (listof list?))]
@@ -25,6 +23,8 @@
     [rename-dn (->m string? string? string? (or/c 0 1) #t)]
     [unbind (->m #t)])])
  (struct-out exn:fail:ldap))
+
+(define mod-list? (listof (list number? string? (listof string?))))
 
 (define-struct (exn:fail:ldap exn:fail:user) ())
 
@@ -46,13 +46,14 @@
     (define ldap-valid (box #f))
     (define ldap-message-c-ptr (box #f))
 
-    (define/private (return-true-or-raise-error r)
-      (cond [(zero? r) #t]
-            [else (raise-ldap-error (ldap-err2string r))]))
+    (define (return-true-or-raise-error r)
+      (or (zero? r)
+          (raise-ldap-error (ldap-err2string r))))
 
-    (define/private (do-thunk-or-raise-error r thunk)
-      (cond [(and (zero? r)) (thunk)]
-            [else (raise-ldap-error (ldap-err2string r))]))
+    (define (do-thunk-or-raise-error r thunk)
+      (if (zero? r)
+          (thunk)
+          (raise-ldap-error (ldap-err2string r))))
 
     ;; check ldap initialize code
     (return-true-or-raise-error initialized)
@@ -61,54 +62,37 @@
 
     (define/private (read-ldap-message
                      [ldap-message (unbox ldap-message-c-ptr)])
-      (define temp-vector (make-vector (count-entries)))
-
-      (let loop ([i 0]
-                 [e ldap-message]
-                 [g (make-gvector)])
-        (unless (false? e)
-
+      (define temp null)
+      (let loop ([e ldap-message])
+        (when e
           (define-values (fst-attr ber) (ldap-first-attribute ld e))
-          (gvector-add! g (cons "dn" (ldap-get-dn ld e)))
-
+          (define g (list (cons "dn" (ldap-get-dn ld e))))
           (let inner-loop ([attr fst-attr])
-            (unless (false? attr)
+            (when attr
               (define vals (ldap-get-values-len ld e attr))
               (for ([i (ldap-count-values-len vals)])
-                (gvector-add! g (cons attr (get-ber-value vals i))))
-
+                (set! g (cons (cons attr (get-ber-value vals i)) g)))
               (ldap-value-free-len vals)
               (inner-loop (ldap-next-attribute ld e ber))))
-
-          (vector-set! temp-vector i (gvector->list g))
-
-          (loop (add1 i)
-                (ldap-next-entry ld e)
-                (make-gvector))))
-
-      (set-box! ldap-data (vector->list temp-vector))
+          (set! temp (cons (reverse g) temp))
+          (loop (ldap-next-entry ld e))))
+      (set-box! ldap-data (reverse temp))
       #t)
 
     (define/public (set-option key value)
-      (define r (ldap-set-option ld key value))
-      (return-true-or-raise-error r))
+      (return-true-or-raise-error (ldap-set-option ld key value)))
 
     (define/public (bind [mechanism 0])
-      (cond [(not (false? (unbox ldap-valid)))
-             (raise-ldap-error "ldap is already bound")]
-            [(false? (unbox ldap-valid))
-             (define r (ldap-sasl-bind-s ld root-dn mechanism
-                                         (make-berval (string-length password)
-                                                      password)
-                                         #f #f #f))
-             (do-thunk-or-raise-error r (λ () (set-box! ldap-valid #t) #t))]))
+      (if (unbox ldap-valid)
+          (raise-ldap-error "ldap is already bound")
+          (do-thunk-or-raise-error (ldap-sasl-bind-s ld root-dn mechanism
+                                                     (make-berval (string-length password)
+                                                                  password)
+                                                     #f #f #f)
+                                   (λ () (set-box! ldap-valid #t) #t))))
 
     (define/private (add-modify ldap-ffi-fn user-dn mod-list)
-      (define mod (for/list ([m mod-list])
-                    (apply lmod m)))
-      (define mod-ptr (ldapmod-c-array-ptr mod))
-      (define r (ldap-ffi-fn ld user-dn mod-ptr #f #f))
-      (return-true-or-raise-error r))
+      (return-true-or-raise-error (ldap-ffi-fn ld user-dn mod-list #f #f)))
 
     (define/public (modify user-dn mod-list)
       (add-modify ldap-modify-ext-s user-dn mod-list))
@@ -117,8 +101,7 @@
       (add-modify ldap-add-ext-s user-dn mod-list))
 
     (define/public (delete dn)
-      (define r (ldap-delete-ext-s ld #f #f))
-      (return-true-or-raise-error r))
+      (return-true-or-raise-error (ldap-delete-ext-s ld #f #f)))
     
     (define/public (search base-dn fltr scope)
       (define-values (r msg)
@@ -136,12 +119,10 @@
       (ldap-count-entries ld (unbox ldap-message-c-ptr)))
 
     (define/public (rename-dn dn newrdn new-superior delete-old-rdn)
-      (define r (ldap-rename-s ld dn newrdn new-superior delete-old-rdn #f #f))
-      (return-true-or-raise-error r))
+      (return-true-or-raise-error
+       (ldap-rename-s ld dn newrdn new-superior delete-old-rdn #f #f)))
 
     (define/public (unbind)
-      (cond [(not (false? (unbox ldap-valid)))
-             (define r (ldap-unbind-ext-s ld #f #f))
-             (do-thunk-or-raise-error r (λ () (set-box! ldap-valid #f) #t))]
-            [(false? (unbox ldap-valid))
-             (raise-ldap-error "ldap is already unbound")]))))
+      (if (unbox ldap-valid)
+          (do-thunk-or-raise-error (ldap-unbind-ext-s ld #f #f) (λ () (set-box! ldap-valid #f) #t))
+          (raise-ldap-error "ldap is already unbound")))))


### PR DESCRIPTION
Gvector should be used only if you need O(1) random access to elements. Simple list is better for  collecting items.

false? is also dropped, because (not (false? x)) == x abd (cond [x res1] [(false? x) res2]) == (if x res1 res2)

_array/list/zero gives easy translation from a list to a zero-ended array.

I don't have an LDAP installation, so I didn't test it. If some test fail, answer here, I'll fix it.
